### PR TITLE
Fix ansible user undefined

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -26,7 +26,7 @@
         name: mrxcitement.dotfiles
       vars:
         dotfiles_repo: '{{ item.repo }}'
-        dotfiles_dest: '/home/{{ ansible_user }}/{{ item.dest }}'
+        dotfiles_dest: "{{ item.dest }}"
         dotfiles_version: '{{ item.version }}'
         dotfiles_username: '{{ item.username | default("") }}'
         dotfiles_password: '{{ item.password | default("") }}'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,10 +12,5 @@ provisioner:
   config_options:
     defaults:
       vault_password_file: "${MOLECULE_SCENARIO_DIRECTORY}/.vault.pw"
-  inventory:
-    host_vars:
-      # use platform name
-      instance:
-        ansible_user: ansible
 verifier:
   name: ansible

--- a/molecule/default/tests/test_clone_repo.yml
+++ b/molecule/default/tests/test_clone_repo.yml
@@ -12,7 +12,6 @@
 
 - name: 'Find symbolic links to the directroy {{ item.dest }}'
   command:
-    chdir: '/home/{{ ansible_user }}'
     cmd: "find . -lname '*{{ item.dest }}*'"
   register: find
   changed_when: False


### PR DESCRIPTION
I had been using a variable set in the inventory to determine the current user
this did not work correctly when running this role in my devbox playbook.
The solution was to 'assume' that the playbook is running in the users home
directory and to not use a 'full' path to the git repo folder, but to use
a relative path from the current users home directory.